### PR TITLE
Update app label

### DIFF
--- a/pinax/webanalytics/apps.py
+++ b/pinax/webanalytics/apps.py
@@ -5,5 +5,5 @@ from django.utils.translation import ugettext_lazy as _
 class AppConfig(BaseAppConfig):
 
     name = "pinax.webanalytics"
-    label = "pinax-webanalytics"
+    label = "pinax_webanalytics"
     verbose_name = _("Pinax Web Analytics")


### PR DESCRIPTION
Fixed "The app label '%s' is not a valid Python identifier." error in Django 3.2