### PR TITLE
Feature/add django 4 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,10 @@ Current analytics services supported:
 
 #### Supported Django and Python Versions
 
-Django / Python | 3.6 | 3.7 | 3.8
---------------- | --- | --- | ---
-2.2  |  *  |  *  |  *
-3.0  |  *  |  *  |  *
+Django / Python | 3.6 | 3.7 | 3.8 | 3.9 | 3.10 | 3.11
+--------------- | --- | --- | --- | -- | -- | --
+3.0  |  *  |  *  |  * | * | * | *
+4.2  |  *  |  *  |  * | * | * | *
 
 
 ## Documentation

--- a/pinax/webanalytics/apps.py
+++ b/pinax/webanalytics/apps.py
@@ -1,5 +1,5 @@
 from django.apps import AppConfig as BaseAppConfig
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class AppConfig(BaseAppConfig):


### PR DESCRIPTION
- Update README to reflect support for Django 4+ and Python 3.9+
- Remove usage of deprecated ugettext_lazy from import